### PR TITLE
ci(pipeline) : Update files to set up ci-pipeline configuration for backend api server

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,14 +74,12 @@ jobs:
       - maven/with_cache:
           steps:
           - run : 
-            name: "Build image and push to gcp registry for api"
-            working_directory: <<parameters.artifact>>/
-            command: mvn -pl :<<parameters.artifact>> test jib:build \
-              -Dspring.profiles.active=<<parameters.domain>> \
-              -Djib.image=<<parameters.domain>> \
-              -DGOOGLE_PROJECT_ID=${GOOGLE_PROJECT_ID}
-
-    
+              name: "Build image and push to gcp registry for api"
+              working_directory: <<parameters.artifact>>/
+              command: mvn -pl :<<parameters.artifact>> test jib:build \
+                -Dspring.profiles.active=<<parameters.domain>> \
+                -Djib.image=<<parameters.domain>> \
+                -DGOOGLE_PROJECT_ID=${GOOGLE_PROJECT_ID}    
 
   test-integration:
     executor: maven/default
@@ -185,8 +183,6 @@ workflows:
           context: gcp-auth-context
           matrix:
             parameters:
-              artifact:
-                - api
               domain:
                 - domain1
                 - domain2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,8 +139,8 @@ workflows:
     when:
       matches:
         #pattern: "^feacher\\/setup-server$"
-        #pattern: "^feacher\\/setup-server$|^feature\\/.+$"
-        pattern: "^feature\\/.+$"
+        pattern: "^feacher\\/setup-server$|^feature\\/.+$"
+        #pattern: "^feature\\/.+$"
         value: << pipeline.git.branch >>
     jobs:
       - install_and_initialize_gcp_cli:
@@ -161,8 +161,8 @@ workflows:
     when:
       matches:
         #pattern: "^(release|feacher\\/test)-.+$"
-        #pattern: "^(release|feacher\\/test)-.+$|^(feature\\/).+$"
-        pattern: "^(feature\\/).+$"
+        pattern: "^(release|feacher\\/test)-.+$|^(feature\\/).+$"
+        #pattern: "^(feature\\/).+$"
         value: <<pipeline.git.branch >>
     jobs:
       - install_and_initialize_gcp_cli:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ workflows:
   setup_workflow:
     when:
       matches:
-        pattern: "^feacher\\/setup-server$"
+        pattern: "^feacher|feature\\/setup-server$"
         value: << pipeline.git.branch >>
     jobs:
       - install_and_initialize_gcp_cli:
@@ -163,7 +163,7 @@ workflows:
   realease_workflow:
     when:
       matches:
-        pattern: "^(release|feacher\\/test)-.+$"
+        pattern: "^(release|feacher|feature\\/test)-.+$"
         value: <<pipeline.git.branch >>
     jobs:
       - install_and_initialize_gcp_cli:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ jobs:
           - decode_gcp_service_key_base64
           - gcp-cli/initialize
           - run: gcloud auth configure-docker --quiet --project ${GOOGLE_PROJECT_ID}
+          - run: cd /home/circleci ; la -al;
           - persist_to_workspace:
               root: .
               paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,10 +77,6 @@ jobs:
               name: "Build image and push to gcp registry for api"
               working_directory: <<parameters.artifact>>/
               command: mvn compile jib:build -Dspring.profiles.active=<<parameters.domain>> -Djib.image=<<parameters.domain>> -DGOOGLE_PROJECT_ID=${GOOGLE_PROJECT_ID}
-                #mvn -pl :<<parameters.artifact>> test jib:build \
-                #-Dspring.profiles.active=<<parameters.domain>> \
-                #-Djib.image=<<parameters.domain>> \
-                #-DGOOGLE_PROJECT_ID=${GOOGLE_PROJECT_ID}    
 
   test-integration:
     executor: maven/default
@@ -143,7 +139,8 @@ workflows:
     when:
       matches:
         #pattern: "^feacher\\/setup-server$"
-        pattern: "^feature\\/.+$"
+        pattern: "^feacher\\/setup-server$|^feature\\/.+$"
+        #pattern: "^feature\\/.+$"
         value: << pipeline.git.branch >>
     jobs:
       - install_and_initialize_gcp_cli:
@@ -164,7 +161,8 @@ workflows:
     when:
       matches:
         #pattern: "^(release|feacher\\/test)-.+$"
-        pattern: "^(feature\\/).+$"
+        pattern: "^(release|feacher\\/test)-.+$|^(feature\\/).+$"
+        #pattern: "^(feature\\/).+$"
         value: <<pipeline.git.branch >>
     jobs:
       - install_and_initialize_gcp_cli:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
                 - run: mkdir -p <<parameters.artifact>>/target/classes
           - run:
               name: "Build image and push to gcp registry"
-              working_directory: <<parameters.artifact>>/
+              #working_directory: <<parameters.artifact>>/
               command: mvn -pl :<<parameters.artifact>> test jib:build -DGOOGLE_PROJECT_ID=${GOOGLE_PROJECT_ID}
 
   build-and-push-image-api:
@@ -75,8 +75,9 @@ jobs:
           steps:
           - run : 
               name: "Build image and push to gcp registry for api"
-              working_directory: <<parameters.artifact>>/
-              command: mvn compile jib:build -Dspring.profiles.active=<<parameters.domain>> -Djib.image=<<parameters.domain>> -DGOOGLE_PROJECT_ID=${GOOGLE_PROJECT_ID}
+              #working_directory: <<parameters.artifact>>/
+              #command: mvn compile jib:build -Dspring.profiles.active=<<parameters.domain>> -Djib.image=<<parameters.domain>> -DGOOGLE_PROJECT_ID=${GOOGLE_PROJECT_ID}
+              command: mvn -pl :<<parameters.artifact>> compile jib:build -Dspring.profiles.active=<<parameters.domain>> -Djib.image=<<parameters.domain>> -DGOOGLE_PROJECT_ID=${GOOGLE_PROJECT_ID}
 
   test-integration:
     executor: maven/default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,9 +63,6 @@ jobs:
       artifact:
         type: string
         default: api
-      domain:
-        type: string
-        default: domain1
     executor: maven/default
     working_directory: ~/project/tiny-nginx/
     steps:
@@ -75,9 +72,7 @@ jobs:
           steps:
           - run : 
               name: "Build image and push to gcp registry for api"
-              #working_directory: <<parameters.artifact>>/
-              #command: mvn compile jib:build -Dspring.profiles.active=<<parameters.domain>> -Djib.image=<<parameters.domain>> -DGOOGLE_PROJECT_ID=${GOOGLE_PROJECT_ID}
-              command: mvn -pl :<<parameters.artifact>> compile jib:build -Dspring.profiles.active=<<parameters.domain>> -Djib.image=<<parameters.domain>> -DGOOGLE_PROJECT_ID=${GOOGLE_PROJECT_ID}
+              command: mvn -pl :<<parameters.artifact>> compile jib:build -Djib.image=<<parameters.artifact>> -DGOOGLE_PROJECT_ID=${GOOGLE_PROJECT_ID}
 
   test-integration:
     executor: maven/default
@@ -179,14 +174,6 @@ workflows:
 
       - build-and-push-image-api:
           context: gcp-auth-context
-          matrix:
-            parameters:
-              domain:
-                - domain1
-                - domain2
-                - domain3
-                - domain4
-                - domain5
           requires:
             - install_and_initialize_gcp_cli
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
           - decode_gcp_service_key_base64
           - gcp-cli/initialize
           - run: gcloud auth configure-docker --quiet --project ${GOOGLE_PROJECT_ID}
-          - run: cd /home/circleci ; ls -al;
+          #- run: cd /home/circleci ; ls -al;
           - persist_to_workspace:
               root: .
               paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,8 @@ workflows:
   setup_workflow:
     when:
       matches:
-        pattern: "^feacher|feature\\/setup-server$"
+        #pattern: "^feacher\\/setup-server$"
+        pattern: "^feature\\/.+$"
         value: << pipeline.git.branch >>
     jobs:
       - install_and_initialize_gcp_cli:
@@ -163,7 +164,8 @@ workflows:
   realease_workflow:
     when:
       matches:
-        pattern: "^(release|feacher|feature\\/test)-.+$"
+        #pattern: "^(release|feacher\\/test)-.+$"
+        pattern: "^(feature\\/).+$"
         value: <<pipeline.git.branch >>
     jobs:
       - install_and_initialize_gcp_cli:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
           - decode_gcp_service_key_base64
           - gcp-cli/initialize
           - run: gcloud auth configure-docker --quiet --project ${GOOGLE_PROJECT_ID}
-          - run: cd /home/circleci ; la -al;
+          - run: cd /home/circleci ; ls -al;
           - persist_to_workspace:
               root: .
               paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,7 +140,6 @@ workflows:
       matches:
         #pattern: "^feacher\\/setup-server$"
         pattern: "^feacher\\/setup-server$|^feature\\/.+$"
-        #pattern: "^feature\\/.+$"
         value: << pipeline.git.branch >>
     jobs:
       - install_and_initialize_gcp_cli:
@@ -162,7 +161,6 @@ workflows:
       matches:
         #pattern: "^(release|feacher\\/test)-.+$"
         pattern: "^(release|feacher\\/test)-.+$|^(feature\\/).+$"
-        #pattern: "^(feature\\/).+$"
         value: <<pipeline.git.branch >>
     jobs:
       - install_and_initialize_gcp_cli:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,31 @@ jobs:
               working_directory: <<parameters.artifact>>/
               command: mvn -pl :<<parameters.artifact>> test jib:build -DGOOGLE_PROJECT_ID=${GOOGLE_PROJECT_ID}
 
+  build-and-push-image-api:
+    parameters:
+      artifact:
+        type: string
+        default: api
+      domain:
+        type: string
+        default: domain1
+    executor: maven/default
+    working_directory: ~/project/tiny-nginx/
+    steps:
+      - checkout
+      - attach_authorized_gcp_sdk
+      - maven/with_cache:
+          steps:
+          - run : 
+            name: "Build image and push to gcp registry for api"
+            working_directory: <<parameters.artifact>>/
+            command: mvn -pl :<<parameters.artifact>> test jib:build \
+              -Dspring.profiles.active=<<parameters.domain>> \
+              -Djib.image=<<parameters.domain>> \
+              -DGOOGLE_PROJECT_ID=${GOOGLE_PROJECT_ID}
+
+    
+
   test-integration:
     executor: maven/default
     working_directory: ~/project/
@@ -154,11 +179,27 @@ workflows:
           requires: 
             - install_and_initialize_gcp_cli
 
+      - build-and-push-image-api:
+          context: gcp-auth-context
+          matrix:
+            parameters:
+              artifact:
+                - api
+              domain:
+                - domain1
+                - domain2
+                - domain3
+                - domain4
+                - domain5
+          requires:
+            - install_and_initialize_gcp_cli
+
       - create-instance-with-container:
           name: create-stage-instance
           context: gcp-auth-context
           requires:
             - build-and-push-image-core
+            - build-and-push-image-api
           instance-name: core-stage
           container-image: gcr.io/${GOOGLE_PROJECT_ID}/core:latest
           metadata-from-file: user-data=${HOME}/project/.cloud-init/exporter/cloud-config.yaml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,6 @@ jobs:
           - decode_gcp_service_key_base64
           - gcp-cli/initialize
           - run: gcloud auth configure-docker --quiet --project ${GOOGLE_PROJECT_ID}
-          #- run: cd /home/circleci ; ls -al;
           - persist_to_workspace:
               root: .
               paths:
@@ -77,10 +76,11 @@ jobs:
           - run : 
               name: "Build image and push to gcp registry for api"
               working_directory: <<parameters.artifact>>/
-              command: mvn -pl :<<parameters.artifact>> test jib:build \
-                -Dspring.profiles.active=<<parameters.domain>> \
-                -Djib.image=<<parameters.domain>> \
-                -DGOOGLE_PROJECT_ID=${GOOGLE_PROJECT_ID}    
+              command: mvn compile jib:build -Dspring.profiles.active=<<parameters.domain>> -Djib.image=<<parameters.domain>> -DGOOGLE_PROJECT_ID=${GOOGLE_PROJECT_ID}
+                #mvn -pl :<<parameters.artifact>> test jib:build \
+                #-Dspring.profiles.active=<<parameters.domain>> \
+                #-Djib.image=<<parameters.domain>> \
+                #-DGOOGLE_PROJECT_ID=${GOOGLE_PROJECT_ID}    
 
   test-integration:
     executor: maven/default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,8 +139,8 @@ workflows:
     when:
       matches:
         #pattern: "^feacher\\/setup-server$"
-        pattern: "^feacher\\/setup-server$|^feature\\/.+$"
-        #pattern: "^feature\\/.+$"
+        #pattern: "^feacher\\/setup-server$|^feature\\/.+$"
+        pattern: "^feature\\/.+$"
         value: << pipeline.git.branch >>
     jobs:
       - install_and_initialize_gcp_cli:
@@ -161,8 +161,8 @@ workflows:
     when:
       matches:
         #pattern: "^(release|feacher\\/test)-.+$"
-        pattern: "^(release|feacher\\/test)-.+$|^(feature\\/).+$"
-        #pattern: "^(feature\\/).+$"
+        #pattern: "^(release|feacher\\/test)-.+$|^(feature\\/).+$"
+        pattern: "^(feature\\/).+$"
         value: <<pipeline.git.branch >>
     jobs:
       - install_and_initialize_gcp_cli:

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -14,6 +14,8 @@
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <spring-boot-starter-web.version>2.6.4</spring-boot-starter-web.version>
         <spring-boot-starter-test.version>2.6.4</spring-boot-starter-test.version>
         <spring-boot-starter-data-jpa.version>2.6.4</spring-boot-starter-data-jpa.version>
@@ -24,6 +26,8 @@
         <junit-jupiter.version>5.8.2</junit-jupiter.version>
         <assertj-core.version>3.11.1</assertj-core.version>
         <mockito-core.version>4.4.0</mockito-core.version>
+        <jib-maven-plugin.version>3.2.1</jib-maven-plugin.version>
+        <jib.image>domain1</jib.image>
     </properties>
 
     <dependencies>
@@ -97,4 +101,23 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.google.cloud.tools</groupId>
+                <artifactId>jib-maven-plugin</artifactId>
+                <version>${jib-maven-plugin.version}</version>
+                <configuration>
+                    <from>
+                        <image>openjdk:11</image>
+                    </from>
+                    <to>
+                        <image>gcr.io/${env.GOOGLE_PROJECT_ID}/${jib.image}</image>
+                    </to>
+                </configuration>
+            </plugin>
+
+        </plugins>
+    </build>
 </project>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -2,20 +2,23 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>tiny-nginx</artifactId>
-        <groupId>kr.flab</groupId>
-        <version>1.0-SNAPSHOT</version>
-    </parent>
     <modelVersion>4.0.0</modelVersion>
-
+    <parent>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <groupId>org.springframework.boot</groupId>
+        <version>2.3.12.RELEASE</version>
+        <relativePath/>
+    </parent>
+    <groupId>kr.flab</groupId>
     <artifactId>api</artifactId>
+    <version>1.0-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <spring-boot-starter-validation.version>2.6.7</spring-boot-starter-validation.version>
         <spring-boot-starter-web.version>2.6.4</spring-boot-starter-web.version>
         <spring-boot-starter-test.version>2.6.4</spring-boot-starter-test.version>
         <spring-boot-starter-data-jpa.version>2.6.4</spring-boot-starter-data-jpa.version>
@@ -31,6 +34,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+            <version>${spring-boot-starter-validation.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
@@ -104,6 +112,10 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -1,0 +1,84 @@
+spring:
+  profiles:
+    group:
+      domain1:
+        - domain1
+        - common
+      domain2:
+        - domain2
+        - common
+      domain3:
+        - domain3
+        - common
+      domain4:
+        - domain4
+        - common
+      domain5:
+        - domain5
+        - common
+
+---
+# common
+spring:
+  config:
+    activate:
+      on-profile: common
+  h2:
+    console:
+      enabled: true
+      path: /h2
+    datasource:
+      jdbc-url: jdbc:h2:mem:test
+      driver-class-name: org.h2.Driver
+      username: sa
+      password:
+
+--- # domain1
+spring:
+  config:
+    activate:
+      on-profile: domain1
+server:
+  port: 80
+  servlet:
+    context-path: /domain1
+
+--- # domain2
+spring:
+  config:
+    activate:
+      on-profile: domain2
+server:
+  port: 80
+  servlet:
+    context-path: /domain2
+
+--- # domain3
+spring:
+  config:
+    activate:
+      on-profile: domain3
+server:
+  port: 80
+  servlet:
+    context-path: /domain3
+
+--- # domain4
+spring:
+  config:
+    activate:
+      on-profile: domain4
+server:
+  port: 80
+  servlet:
+    context-path: /domain4
+
+--- # domain5
+spring:
+  config:
+    activate:
+      on-profile: domain5
+server:
+  port: 80
+  servlet:
+    context-path: /domain5

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -1,28 +1,9 @@
-spring:
-  profiles:
-    group:
-      domain1:
-        - domain1
-        - common
-      domain2:
-        - domain2
-        - common
-      domain3:
-        - domain3
-        - common
-      domain4:
-        - domain4
-        - common
-      domain5:
-        - domain5
-        - common
+server:
+  port: 8080
 
----
-# common
+--- # db
 spring:
-  config:
-    activate:
-      on-profile: common
+  profile: db
   h2:
     console:
       enabled: true
@@ -35,9 +16,7 @@ spring:
 
 --- # domain1
 spring:
-  config:
-    activate:
-      on-profile: domain1
+  profiles: domain1
 server:
   port: 80
   servlet:
@@ -45,9 +24,7 @@ server:
 
 --- # domain2
 spring:
-  config:
-    activate:
-      on-profile: domain2
+  profile: domain2
 server:
   port: 80
   servlet:
@@ -55,9 +32,7 @@ server:
 
 --- # domain3
 spring:
-  config:
-    activate:
-      on-profile: domain3
+  profile: domain3
 server:
   port: 80
   servlet:
@@ -65,9 +40,7 @@ server:
 
 --- # domain4
 spring:
-  config:
-    activate:
-      on-profile: domain4
+  profile: domain4
 server:
   port: 80
   servlet:
@@ -75,9 +48,7 @@ server:
 
 --- # domain5
 spring:
-  config:
-    activate:
-      on-profile: domain5
+  profile: domain5
 server:
   port: 80
   servlet:


### PR DESCRIPTION
1. Multiple Profiles 설정
   - Multi Configuration 설정을 위해서 application.yml 파일을 추가했습니다.
   - domain1 ~ domain5 로 접속할 수 있도록 설정되어 있습니다.
      - 접속 예시 1: `http://localhost/domain1/api`
      - 접속 예시 2: `http://localhost/domain5/api`

2. jib plugin 추가
   - 프로젝트의 이미지 빌드를 돕기 위해 jib 플러그인을 모듈에 추가했습니다.
   - dependency
      - jib-maven-plugin:3.2.1

3. CI/CD 파이프라인에 api-server 관련 로직 추가
   - realease workflow
      - 이미지 빌드 플로우에 api-server의 이미지 build를 위한 로직을 추가했습니다.
      - 브랜치 : 'feature/*' 추가
      <img width="1388" alt="스크린샷 2022-04-28 오후 3 02 47" src="https://user-images.githubusercontent.com/51159167/165687297-a1c41725-5b1c-415c-aff5-bd9fafade8bf.png">
 